### PR TITLE
feat: Implement static and dynamic arrays

### DIFF
--- a/examples/dynamic_array_example.notal
+++ b/examples/dynamic_array_example.notal
@@ -1,0 +1,37 @@
+PROGRAM DynamicArrayExample
+{ Contoh penggunaan array dinamis multidimensional }
+
+KAMUS
+  { Deklarasi array dinamis 2D }
+  dynMatrix: array of array of integer
+
+  { Variabel untuk ukuran dan iterasi }
+  rows, cols: integer
+  i, j: integer
+
+ALGORITMA
+  { Meminta ukuran dari pengguna }
+  output("Masukkan jumlah baris untuk matriks dinamis:")
+  input(rows)
+  output("Masukkan jumlah kolom untuk matriks dinamis:")
+  input(cols)
+
+  { Alokasi memori untuk array dinamis }
+  allocate(dynMatrix, rows, cols)
+
+  { Mengisi matriks dengan nilai }
+  output("Mengisi matriks dinamis...")
+  i traversal [0..rows-1]
+    j traversal [0..cols-1]
+      dynMatrix[i][j] <- (i + 1) * (j + 1)
+
+  { Menampilkan isi matriks }
+  output("Isi Matriks Dinamis ", rows, "x", cols, ":")
+  i traversal [0..rows-1]
+    j traversal [0..cols-1]
+      output("dynMatrix[", i, "][", j, "] = ", dynMatrix[i][j])
+
+  { Dealokasi memori }
+  output("Dealokasi memori matriks...")
+  deallocate[2](dynMatrix)
+  output("Memori telah dibebaskan.")

--- a/examples/static_array_example.notal
+++ b/examples/static_array_example.notal
@@ -1,0 +1,21 @@
+PROGRAM StaticArrayExample
+{ Contoh penggunaan array statis multidimensional }
+
+KAMUS
+  { Deklarasi matriks 3x3 untuk menyimpan data integer }
+  matrix: array[1..3][1..3] of integer
+
+  { Variabel untuk iterasi }
+  i, j: integer
+
+ALGORITMA
+  { Mengisi matriks dengan nilai i * j }
+  i traversal [1..3]
+    j traversal [1..3]
+      matrix[i][j] <- i * j
+
+  { Menampilkan isi matriks }
+  output("Isi Matriks 3x3:")
+  i traversal [1..3]
+    j traversal [1..3]
+      output("Matrix[", i, "][", j, "] = ", matrix[i][j])

--- a/include/notal_transpiler/ASTPrinter.h
+++ b/include/notal_transpiler/ASTPrinter.h
@@ -19,6 +19,10 @@ public:
     std::any visit(std::shared_ptr<ast::KamusStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::AlgoritmaStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::VarDeclStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::StaticArrayDeclStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::DynamicArrayDeclStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::AllocateStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::DeallocateStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::ConstDeclStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::InputStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::RecordTypeDeclStmt> stmt) override;
@@ -48,6 +52,7 @@ public:
     std::any visit(std::shared_ptr<ast::Call> expr) override;
     std::any visit(std::shared_ptr<ast::FieldAccess> expr) override;
     std::any visit(std::shared_ptr<ast::FieldAssign> expr) override;
+    std::any visit(std::shared_ptr<ast::ArrayAccess> expr) override;
 
 private:
     std::string parenthesize(const std::string& name, const std::vector<std::shared_ptr<ast::Expr>>& exprs);

--- a/include/notal_transpiler/CodeGenerator.h
+++ b/include/notal_transpiler/CodeGenerator.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <vector>
 
 namespace notal {
 
@@ -20,6 +21,10 @@ public:
     std::any visit(std::shared_ptr<ast::KamusStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::AlgoritmaStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::VarDeclStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::StaticArrayDeclStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::DynamicArrayDeclStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::AllocateStmt> stmt) override;
+    std::any visit(std::shared_ptr<ast::DeallocateStmt> stmt) override;
     std::any visit(std::shared_ptr<ast::ConstDeclStmt> stmt) override; // Added
     std::any visit(std::shared_ptr<ast::InputStmt> stmt) override;     // Added
     std::any visit(std::shared_ptr<ast::RecordTypeDeclStmt> stmt) override; // Added
@@ -49,6 +54,7 @@ public:
     std::any visit(std::shared_ptr<ast::Call> expr) override;
     std::any visit(std::shared_ptr<ast::FieldAccess> expr) override;
     std::any visit(std::shared_ptr<ast::FieldAssign> expr) override;
+    std::any visit(std::shared_ptr<ast::ArrayAccess> expr) override;
 
 private:
     std::stringstream out;
@@ -57,8 +63,9 @@ private:
     bool forwardDeclare = false;
     std::string currentFunctionName;
     std::map<std::string, std::shared_ptr<ast::Literal>> constants;
-    std::map<std::string, std::shared_ptr<ast::ConstrainedVarDeclStmt>> constrainedVars; // Track constrained variables
-    std::vector<std::string> loopVariables; // Track loop variables
+    std::map<std::string, std::shared_ptr<ast::ConstrainedVarDeclStmt>> constrainedVars;
+    std::map<std::string, int> dynamicArrayDimensions;
+    std::vector<std::string> loopVariables;
     
     void indent();
     void generateParameterList(const std::vector<ast::Parameter>& params);

--- a/include/notal_transpiler/Parser.h
+++ b/include/notal_transpiler/Parser.h
@@ -28,9 +28,12 @@ private:
     std::shared_ptr<ast::AlgoritmaStmt> algoritma();
     std::shared_ptr<ast::Stmt> declaration();
     std::shared_ptr<ast::Stmt> varDeclaration();
+    std::shared_ptr<ast::Stmt> arrayDeclaration(Token name);
     std::shared_ptr<ast::Stmt> constantDeclaration(); // Added
     std::shared_ptr<ast::Stmt> typeDeclaration();     // Added for type declarations
     std::shared_ptr<ast::Stmt> statement();
+    std::shared_ptr<ast::Stmt> allocateStatement();
+    std::shared_ptr<ast::Stmt> deallocateStatement();
     std::shared_ptr<ast::Stmt> inputStatement();      // Added
     std::shared_ptr<ast::Stmt> ifStatement();
     std::shared_ptr<ast::Stmt> ifStatementBody(int parentIndentLevel); // Helper for recursion
@@ -65,6 +68,7 @@ private:
     std::shared_ptr<ast::Expr> unary();
     std::shared_ptr<ast::Expr> call();
     std::shared_ptr<ast::Expr> finishCall(std::shared_ptr<ast::Expr> callee);
+    std::shared_ptr<ast::Expr> arrayAccess(std::shared_ptr<ast::Expr> callee);
     std::shared_ptr<ast::Expr> primary();
 
 

--- a/include/notal_transpiler/Token.h
+++ b/include/notal_transpiler/Token.h
@@ -26,6 +26,7 @@ namespace notal {
         PROCEDURE, FUNCTION,
         INPUT, OUTPUT,
         POINTER, TO,
+        ARRAY, OF,
         ALLOCATE, DEALLOCATE,
         
         // Logical Operators
@@ -55,7 +56,7 @@ namespace notal {
         LPAREN, RPAREN,     // ( )
         LBRACKET, RBRACKET, // [ ]
         LANGLE, RANGLE,     // < > (for record types)
-        COLON, COMMA, DOT,  // : , .
+        COLON, COMMA, DOT, DOT_DOT, // : , . ..
         PIPE, // |
 
         // Comments
@@ -102,6 +103,8 @@ namespace notal {
         {"output", TokenType::OUTPUT},
         {"pointer", TokenType::POINTER},
         {"to", TokenType::TO},
+        {"array", TokenType::ARRAY},
+        {"of", TokenType::OF},
         {"allocate", TokenType::ALLOCATE},
         {"deallocate", TokenType::DEALLOCATE},
         {"and", TokenType::AND},

--- a/src/ASTPrinter.cpp
+++ b/src/ASTPrinter.cpp
@@ -38,6 +38,26 @@ std::any ASTPrinter::visit(std::shared_ptr<ast::VarDeclStmt> stmt) {
     return "(VAR_DECL " + stmt->name.lexeme + " : " + stmt->type.lexeme + ")";
 }
 
+std::any ASTPrinter::visit(std::shared_ptr<ast::StaticArrayDeclStmt> stmt) {
+    (void)stmt;
+    return "(static_array_decl ...)";
+}
+
+std::any ASTPrinter::visit(std::shared_ptr<ast::DynamicArrayDeclStmt> stmt) {
+    (void)stmt;
+    return "(dynamic_array_decl ...)";
+}
+
+std::any ASTPrinter::visit(std::shared_ptr<ast::AllocateStmt> stmt) {
+    (void)stmt;
+    return "(allocate ...)";
+}
+
+std::any ASTPrinter::visit(std::shared_ptr<ast::DeallocateStmt> stmt) {
+    (void)stmt;
+    return "(deallocate ...)";
+}
+
 std::any ASTPrinter::visit(std::shared_ptr<ast::ConstDeclStmt> stmt) {
     return parenthesize("CONST_DECL " + stmt->name.lexeme + " : " + stmt->type.lexeme, {stmt->initializer});
 }
@@ -57,7 +77,7 @@ std::any ASTPrinter::visit(std::shared_ptr<ast::OutputStmt> stmt) {
 // --- Expression Visitors ---
 
 std::any ASTPrinter::visit(std::shared_ptr<ast::Assign> expr) {
-    return parenthesize("<- " + expr->name.lexeme, {expr->value});
+    return parenthesize("<-", {expr->target, expr->value});
 }
 
 std::any ASTPrinter::visit(std::shared_ptr<ast::Binary> expr) {
@@ -90,6 +110,11 @@ std::any ASTPrinter::visit(std::shared_ptr<ast::Literal> expr) {
         return "'" + std::any_cast<std::string>(expr->value) + "'";
     }
     return std::string("null");
+}
+
+std::any ASTPrinter::visit(std::shared_ptr<ast::ArrayAccess> expr) {
+    (void)expr;
+    return "(array_access ...)";
 }
 
 // --- Unimplemented Visitors (for now) ---
@@ -223,4 +248,3 @@ std::string ASTPrinter::indent() {
 }
 
 } // namespace notal
-

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -42,7 +42,9 @@ Token Lexer::nextToken() {
         case ']': return makeToken(TokenType::RBRACKET);
         case ':': return makeToken(TokenType::COLON);
         case ',': return makeToken(TokenType::COMMA);
-        case '.': return makeToken(TokenType::DOT);
+        case '.':
+            if (match('.')) return makeToken(TokenType::DOT_DOT);
+            return makeToken(TokenType::DOT);
         case '+': return makeToken(TokenType::PLUS);
         case '-':
             if (match('>')) return makeToken(TokenType::ARROW);

--- a/tests/array_test.cpp
+++ b/tests/array_test.cpp
@@ -1,0 +1,188 @@
+#include <gtest/gtest.h>
+#include "test_helpers.h"
+
+TEST(ArrayTest, StaticArrayDeclaration) {
+    std::string notal_code = R"(
+PROGRAM StaticArrayTest
+KAMUS
+    matrix: array[1..10][1..5] of integer
+    cube: array[0..2][0..2][0..2] of real
+ALGORITMA
+    matrix[1][1] <- 10
+)";
+    std::string expected_pascal_code = R"(program StaticArrayTest;
+
+var
+  matrix: array[1..10, 1..5] of integer;
+  cube: array[0..2, 0..2, 0..2] of real;
+
+begin
+  matrix[1, 1] := 10;
+end.
+)";
+    std::string generated_code = transpile(notal_code);
+    ASSERT_EQ(normalizeCode(generated_code), normalizeCode(expected_pascal_code));
+}
+
+TEST(ArrayTest, DynamicArrayDeclarationAndAllocation) {
+    std::string notal_code = R"(
+PROGRAM DynamicArrayTest
+KAMUS
+    data1D: array of integer
+    data2D: array of array of real
+    data3D: array of array of array of boolean
+ALGORITMA
+    allocate(data1D, 10)
+    allocate(data2D, 5, 5)
+    allocate(data3D, 2, 3, 4)
+)";
+    std::string expected_pascal_code = R"(program DynamicArrayTest;
+
+var
+  data1D: array of integer;
+  data2D: array of array of real;
+  data3D: array of array of array of boolean;
+
+begin
+  SetLength(data1D, 10);
+  SetLength(data2D, 5, 5);
+  SetLength(data3D, 2, 3, 4);
+end.
+)";
+    std::string generated_code = transpile(notal_code);
+    ASSERT_EQ(normalizeCode(generated_code), normalizeCode(expected_pascal_code));
+}
+
+TEST(ArrayTest, ArrayAccessAndAssignment) {
+    std::string notal_code = R"(
+PROGRAM ArrayAccessTest
+KAMUS
+    staticArr: array[0..4] of integer
+    dynArr: array of string
+ALGORITMA
+    allocate(dynArr, 5)
+    staticArr[0] <- 100
+    staticArr[1] <- staticArr[0] * 2
+    dynArr[4] <- "Hello"
+    output(staticArr[1])
+    output(dynArr[4])
+)";
+    std::string expected_pascal_code = R"(program ArrayAccessTest;
+
+var
+  staticArr: array[0..4] of integer;
+  dynArr: array of string;
+
+begin
+  SetLength(dynArr, 5);
+  staticArr[0] := 100;
+  staticArr[1] := (staticArr[0] * 2);
+  dynArr[4] := 'Hello';
+  writeln(staticArr[1]);
+  writeln(dynArr[4]);
+end.
+)";
+    std::string generated_code = transpile(notal_code);
+    ASSERT_EQ(normalizeCode(generated_code), normalizeCode(expected_pascal_code));
+}
+
+TEST(ArrayTest, MultiDimensionalAccess) {
+    std::string notal_code = R"(
+PROGRAM MultiDimTest
+KAMUS
+    matrix: array[1..2][1..2] of integer
+ALGORITMA
+    matrix[1][1] <- 1
+    matrix[1][2] <- 2
+    matrix[2][1] <- 3
+    matrix[2][2] <- matrix[1][1] + matrix[1][2] + matrix[2][1]
+    output(matrix[2][2])
+)";
+    std::string expected_pascal_code = R"(program MultiDimTest;
+
+var
+  matrix: array[1..2, 1..2] of integer;
+
+begin
+  matrix[1, 1] := 1;
+  matrix[1, 2] := 2;
+  matrix[2, 1] := 3;
+  matrix[2, 2] := ((matrix[1, 1] + matrix[1, 2]) + matrix[2, 1]);
+  writeln(matrix[2, 2]);
+end.
+)";
+    std::string generated_code = transpile(notal_code);
+    ASSERT_EQ(normalizeCode(generated_code), normalizeCode(expected_pascal_code));
+}
+
+TEST(ArrayTest, Deallocation) {
+    std::string notal_code = R"(
+PROGRAM DeallocationTest
+KAMUS
+    data1D: array of integer
+    data2D: array of array of integer
+    ptr: pointer to integer
+ALGORITMA
+    allocate(data1D, 10)
+    deallocate[1](data1D)
+
+    allocate(data2D, 5, 5)
+    deallocate[2](data2D)
+
+    allocate(ptr)
+    deallocate(ptr)
+)";
+    std::string expected_pascal_code = R"(program DeallocationTest;
+
+var
+  data1D: array of integer;
+  data2D: array of array of integer;
+  ptr: ^integer;
+
+begin
+  SetLength(data1D, 10);
+  SetLength(data1D, 0);
+  SetLength(data2D, 5, 5);
+  SetLength(data2D, 0, 0);
+  New(ptr);
+  Dispose(ptr);
+end.
+)";
+    std::string generated_code = transpile(notal_code);
+    ASSERT_EQ(normalizeCode(generated_code), normalizeCode(expected_pascal_code));
+}
+
+TEST(ArrayTest, DeallocationMismatchError) {
+    std::string notal_code = R"(
+PROGRAM DeallocationMismatchTest
+KAMUS
+    data2D: array of array of integer
+ALGORITMA
+    allocate(data2D, 5, 5)
+    deallocate[3](data2D)
+)";
+    ASSERT_THROW(transpile(notal_code), std::runtime_error);
+}
+
+TEST(ArrayTest, DeallocationWithEmptyBrackets) {
+    std::string notal_code = R"(
+PROGRAM DeallocEmptyBracketTest
+KAMUS
+    data1D: array of integer
+ALGORITMA
+    allocate(data1D, 10)
+    deallocate[](data1D)
+)";
+    std::string expected_pascal_code = R"(program DeallocEmptyBracketTest;
+
+var
+  data1D: array of integer;
+
+begin
+  SetLength(data1D, 10);
+  SetLength(data1D, 0);
+end.
+)";
+    std::string generated_code = transpile(notal_code);
+    ASSERT_EQ(normalizeCode(generated_code), normalizeCode(expected_pascal_code));
+}


### PR DESCRIPTION
This commit introduces support for static and dynamic multidimensional arrays in the NOTAL transpiler.

Key features implemented:
-   **Static Arrays**: Added parsing and code generation for static array declarations with specified bounds (e.g., `array[1..10] of integer`).
-   **Dynamic Arrays**: Implemented support for dynamic array declarations (`array of array of ...`), memory allocation (`allocate`), and deallocation (`deallocate`).
-   **Array Access**: Enabled multi-dimensional array access (e.g., `myArray[i][j]`) with correct translation to Pascal's comma-separated syntax.
-   **Error Handling**: Added a static check in the code generator to ensure the dimension specified in `deallocate[n]` matches the declared dimension of the dynamic array.

A comprehensive test suite (`tests/array_test.cpp`) has been added to validate the new functionality, and example files (`examples/static_array_example.notal`, `examples/dynamic_array_example.notal`) have been created to demonstrate usage.