### PR TITLE
feat: Implement power operator and expressions

### DIFF
--- a/include/notal_transpiler/Parser.h
+++ b/include/notal_transpiler/Parser.h
@@ -65,6 +65,7 @@ private:
     std::shared_ptr<ast::Expr> comparison();
     std::shared_ptr<ast::Expr> term();
     std::shared_ptr<ast::Expr> factor();
+        std::shared_ptr<ast::Expr> power();
     std::shared_ptr<ast::Expr> unary();
     std::shared_ptr<ast::Expr> call();
     std::shared_ptr<ast::Expr> finishCall(std::shared_ptr<ast::Expr> callee);

--- a/src/CodeGenerator.cpp
+++ b/src/CodeGenerator.cpp
@@ -287,6 +287,12 @@ std::any CodeGenerator::visit(std::shared_ptr<ast::Assign> expr) {
 }
 
 std::any CodeGenerator::visit(std::shared_ptr<ast::Binary> expr) {
+    if (expr->op.type == TokenType::POWER) {
+        std::string base = evaluate(expr->left);
+        std::string exponent = evaluate(expr->right);
+        return "trunc(exp(" + exponent + " * ln(" + base + ")))";
+    }
+
     std::string op = expr->op.lexeme;
     if (expr->op.type == TokenType::AMPERSAND) op = "+";
     return "(" + evaluate(expr->left) + " " + op + " " + evaluate(expr->right) + ")";

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -827,10 +827,20 @@ std::shared_ptr<ast::Expr> Parser::term() {
 }
 
 std::shared_ptr<ast::Expr> Parser::factor() {
-    std::shared_ptr<ast::Expr> expr = unary();
+    std::shared_ptr<ast::Expr> expr = power();
     while (match({TokenType::DIVIDE, TokenType::MULTIPLY, TokenType::MOD, TokenType::DIV})) {
         Token op = previous();
-        std::shared_ptr<ast::Expr> right = unary();
+        std::shared_ptr<ast::Expr> right = power();
+        expr = std::make_shared<ast::Binary>(expr, op, right);
+    }
+    return expr;
+}
+
+std::shared_ptr<ast::Expr> Parser::power() {
+    std::shared_ptr<ast::Expr> expr = unary();
+    if (match({TokenType::POWER})) {
+        Token op = previous();
+        std::shared_ptr<ast::Expr> right = power();
         expr = std::make_shared<ast::Binary>(expr, op, right);
     }
     return expr;


### PR DESCRIPTION
This commit implements the power (`^`) operator as specified in the language documentation.

- The parser has been updated to recognize the `^` operator with right-associativity and higher precedence than multiplicative operators.
- The code generator is updated to transpile the `^` operator into the corresponding Pascal expression `trunc(exp(exponent * ln(base)))`.
- String concatenation is handled by the `+` operator, as requested.